### PR TITLE
use text-center instead of justify-content-center in many places

### DIFF
--- a/apps/contrib/templates/lrex_contrib/confirm_delete.html
+++ b/apps/contrib/templates/lrex_contrib/confirm_delete.html
@@ -2,15 +2,11 @@
 {% load crispy_forms_tags %}
 
 {% block content %}
-<div class="p-4 border bg-white">
-<form action="" method="post">{% csrf_token %}
-    <p class="row justify-content-center">{{ view.message }}</p>
-    <div class="row justify-content-center">
-    <span>
+<form action="" method="post" class="p-4 border bg-white">{% csrf_token %}
+    <p class="text-center">{{ view.message }}</p>
+    <div class="text-center">
         <input type="submit" value="Delete" class="btn btn-outline-danger btn-sm"/>
         <a href="{{ view.get_success_url }}" class="btn btn-outline-secondary btn-sm">Cancel</a>
-    </span>
     </div>
 </form>
-</div>
 {% endblock %}

--- a/apps/experiment/templates/lrex_experiment/experiment_list.html
+++ b/apps/experiment/templates/lrex_experiment/experiment_list.html
@@ -1,7 +1,7 @@
 {% extends "lrex_home/base.html" %}
 
 {% block content %}
-<div class="row justify-content-center mb-2">
+<div class="text-center mb-2">
     <a href="{% url 'experiment-create' study.slug %}"
        class="btn btn-primary btn-sm mx-1">
         New Experiment

--- a/apps/experiment/templates/lrex_experiment/experiment_results.html
+++ b/apps/experiment/templates/lrex_experiment/experiment_results.html
@@ -1,8 +1,8 @@
 {% extends "lrex_home/base.html" %}
 
 {% block content %}
-<div class="row justify-content-center mb-2">
-    <div class="dropdown">
+<div class="text-center mb-2">
+    <div class="dropdown d-inline">
         <button class="btn  btn-primary btn-sm mx-1 dropdown-toggle" type="button" id="dropdownAggregateBy" data-toggle="dropdown"
                 aria-haspopup="true" aria-expanded="false">
             Aggregated by: {{ view.aggregate_by_label }}

--- a/apps/item/templates/lrex_item/item_list.html
+++ b/apps/item/templates/lrex_item/item_list.html
@@ -1,7 +1,7 @@
 {% extends "lrex_home/base.html" %}
 
 {% block content %}
-<div class="row justify-content-center mb-2">
+<div class="text-center mb-2">
     <a
         {% if study.has_text_items %}
         href="{% url 'text-item-create' experiment.slug %}"
@@ -19,7 +19,7 @@
        class="btn btn-primary btn-sm mx-1">
         Upload CSV
     </a>
-    <form method="post">
+    <form method="post" class="d-inline">
         {% csrf_token %}
         <button type="submit" name="action" value="validate" class="btn btn-primary btn-sm mx-1">
             Validate

--- a/apps/item/templates/lrex_item/itemlist_list.html
+++ b/apps/item/templates/lrex_item/itemlist_list.html
@@ -1,8 +1,8 @@
 {% extends "lrex_home/base.html" %}
 
 {% block content %}
-<div class="row justify-content-center mb-2">
-    <form name="actionForm" id="actionForm" method="POST"/>
+<div class="text-center mb-2">
+    <form name="actionForm" id="actionForm" method="POST" class="d-inline">
     {% csrf_token %}
     <input class="span2" id="action" name="action" type="text" hidden="hidden">
     <div class="btn-group">

--- a/apps/study/templates/lrex_study/study_detail.html
+++ b/apps/study/templates/lrex_study/study_detail.html
@@ -4,7 +4,7 @@
 {% load static %}
 
 {% block content %}
-<div class="row small text-secondary justify-content-center mb-2">
+<div class="text-center mb-2">
     <form class="form-inline" method="post">
         {% csrf_token %}
         {% if study.is_published %}

--- a/apps/study/templates/lrex_study/study_list.html
+++ b/apps/study/templates/lrex_study/study_list.html
@@ -2,7 +2,7 @@
 {% load progress_tags %}
 
 {% block content %}
-<div class="row justify-content-center mb-2">
+<div class="text-center mb-2">
     <a href="{% url 'study-create' %}" class="btn btn-primary btn-sm mx-1">
         New study
     </a>

--- a/apps/trial/templates/lrex_trial/questionnaire_list.html
+++ b/apps/trial/templates/lrex_trial/questionnaire_list.html
@@ -1,7 +1,7 @@
 {% extends "lrex_home/base.html" %}
 
 {% block content %}
-<div class="row justify-content-center mb-2">
+<div class="text-center mb-2">
     {% if view.consider_blocks %}
     <a href="{% url 'questionnaire-generate' study.slug %}"
        class="btn btn-primary btn-sm mx-1">
@@ -12,7 +12,7 @@
         Add/edit block instructions
     </a>
     {% else %}
-    <form name="actionForm" id="actionForm" method="POST"/>
+    <form name="actionForm" id="actionForm" method="POST" class="d-inline">
         {% csrf_token %}
         <input class="span2" id="action" name="action" type="text" hidden="hidden">
         <div class="btn-group">

--- a/apps/trial/templates/lrex_trial/rating_form.html
+++ b/apps/trial/templates/lrex_trial/rating_form.html
@@ -9,7 +9,7 @@
         {{ view.questionnaire_item.item.textitem.text|linebreaks }}
     </p>
     {% else %}
-    <div class="row justify-content-center my-2">
+    <div class="text-center my-2">
         <audio controls="controls" autoplay="autoplay">
             <source src="{{ view.questionnaire_item.item.audiolinkitem.url }}">
             Your browser does not support the <code>audio</code> element.

--- a/apps/trial/templates/lrex_trial/ratings_form.html
+++ b/apps/trial/templates/lrex_trial/ratings_form.html
@@ -10,7 +10,7 @@
         {{ view.questionnaire_item.item.textitem.text|linebreaks }}
     </p>
     {% else %}
-    <div class="row justify-content-center my-2">
+    <div class="text-center my-2">
         <audio controls="controls" autoplay="autoplay">
             <source src="{{ view.questionnaire_item.item.audiolinkitem.url }}">
             Your browser does not support the <code>audio</code> element.

--- a/apps/trial/templates/lrex_trial/trial_list.html
+++ b/apps/trial/templates/lrex_trial/trial_list.html
@@ -1,9 +1,9 @@
 {% extends "lrex_home/base.html" %}
 
 {% block content %}
-<div class="row justify-content-center mb-2">
+<div class="text-center mb-2">
     {%if study.generate_participation_code %}
-    <form method="post">
+    <form method="post" class="d-inline">
         {% csrf_token %}
         <button type="submit" name="action" value="download_proofs"
                 class="btn btn-primary btn-sm mx-1">


### PR DESCRIPTION
See also https://github.com/2e2a/l-rex/pull/9/commits/821abd5123d8fa84e91889dc131c498d7a669d55

Explanation: `row` basically does two things: Set display to flex and add a negative margin on the sides. All children of a row should be columns. If you feel the urge to use `row` without `col`, you are probably better of using something else, e.g. `d-flex`.