### PR TITLE
HTML5 datepicker

### DIFF
--- a/apps/contrib/datefield.py
+++ b/apps/contrib/datefield.py
@@ -1,0 +1,22 @@
+from django import forms
+from django.db import models
+
+
+class DateInput(forms.DateInput):
+    def __init__(self, attrs={}, **kwargs):
+        defaults = {
+            'placeholder': 'yyyy-mm-dd',
+            'type': 'date',
+        }
+        defaults.update(attrs)
+        super().__init__(format='%Y-%m-%d', attrs=defaults, **kwargs)
+
+
+class DateFormField(forms.DateField):
+    widget = DateInput
+
+
+class DateField(models.DateField):
+    def formfield(self, **kwargs):
+        kwargs.setdefault('form_class', DateFormField)
+        return super().formfield(**kwargs)

--- a/apps/study/models.py
+++ b/apps/study/models.py
@@ -10,6 +10,7 @@ from django.utils.functional import cached_property
 
 from apps.contrib import math
 from apps.contrib.utils import slugify_unique
+from apps.contrib.datefield import DateField
 
 
 class StudyStatus(Enum):
@@ -60,10 +61,9 @@ class Study(models.Model):
         help_text='This text will be presented to the participant after the experiment is finished.',
         default='Thank you for participating!',
     )
-    end_date = models.DateField(
+    end_date = DateField(
         blank=True,
         null=True,
-        help_text='If you want to set a participation deadline, enter a date in the format YYYY-MM-DD.',
     )
     trial_limit = models.IntegerField(
         null=True,


### PR DESCRIPTION
[Browser support for the native datepicker](https://caniuse.com/#feat=input-datetime) is still incomplete. The only notable execption at this point is safari. There is also no harm in enabeling it for the browsers that do support it. 

Note that the support is worse for `datetime-local` which is not yet supported by firefox. There are two DateTimeFields in the models, but as far as I could see they do not show up in any forms. If you want to have a datepicker for datetime fields in the future, I recommend splitting it into two HTML inputs. I have a code sample in my [django-utils](https://github.com/xi/django-utils/blob/master/utils/datefields.py) repo.